### PR TITLE
Upgrade `certifi` package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
+Django==3.2.16
 api-client==1.3.1
 asgiref==3.5.2
-certifi==2022.6.15
+certifi==2022.12.07
 charset-normalizer==2.1.0
 click==8.1.3
 distlib==0.3.4
-Django==3.2.16
 filelock==3.7.0
 idna==3.3
 pbr==5.9.0
@@ -19,6 +19,6 @@ stevedore==3.5.0
 tenacity==8.0.1
 tomli==2.0.1
 urllib3==1.26.9
-virtualenv==20.14.1
 virtualenv-clone==0.5.7
+virtualenv==20.14.1
 virtualenvwrapper==4.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==3.2.16
 api-client==1.3.1
 asgiref==3.5.2
-certifi==2022.12.07
+certifi>=2022.12.07
 charset-normalizer==2.1.0
 click==8.1.3
 distlib==0.3.4


### PR DESCRIPTION
## Context

- addresses [Certifi removing TrustCor root certificate](https://github.com/advisories/GHSA-43fp-rhv2-5gv8)
- upgrades `certifi` to version `2022.12.07`