### PR TITLE
Fix - TRSV2-596 - Extract zipfile metadata

### DIFF
--- a/v2_api_client/shared/upload_handler/metadata.py
+++ b/v2_api_client/shared/upload_handler/metadata.py
@@ -27,7 +27,7 @@ class Extractor:
             "application/vnd.oasis.opendocument.text",
             "application/vnd.oasis.opendocument.spreadsheet",
         ):
-            data = ODFExtractor().extract(data)
+            data = OpenOfficeExtractor().extract(data)
         elif file_format == "application/zip":
             data = ZIPExtractor().extract(data)
         else:
@@ -58,16 +58,21 @@ class ZIPExtractor(BaseExtractMetaData):
                         if os.path.isfile(os.path.join(tmpdirname, f))
                     ]
                     for file in extracted_files:
-                        with open(os.path.join(tmpdirname, file), "rb") as file_bytes:
-                            if mimetype := mimetypes.guess_type(file)[0]:
+                        input_file_path = os.path.join(tmpdirname, file)
+                        output_file_path = os.path.join(output_tmpdirname, file)
+                        if mimetype := mimetypes.guess_type(file)[0]:
+                            with open(input_file_path, "rb") as file_bytes:
                                 _, stripped_bytes = extractor(
                                     file_bytes.read(), mimetype
                                 )
-                                with open(
-                                    os.path.join(output_tmpdirname, file), "wb"
-                                ) as f:
+                                with open(output_file_path, "wb") as f:
                                     f.write(stripped_bytes.read())
+                        else:
+                            # the mimetype cannot be determined, so we just copy the file
+                            shutil.copyfile(input_file_path, output_file_path)
 
+                    # checking that the new zip file contains the same number of files as the
+                    # original zip file
                     assert len(extracted_files) == len(os.listdir(output_tmpdirname))
                     stripped_zip_path = shutil.make_archive(
                         os.path.join(tmpdirname, "stripped"), "zip", output_tmpdirname
@@ -79,7 +84,7 @@ class ZIPExtractor(BaseExtractMetaData):
         return stripped_zip_bytes
 
 
-class ODFExtractor(BaseExtractMetaData):
+class OpenOfficeExtractor(BaseExtractMetaData):
     def extract(self, data):
         sanitised_data = io.BytesIO()
         tags = ["creator", "title", "description", "subject"]
@@ -102,6 +107,7 @@ class ODFExtractor(BaseExtractMetaData):
         with zipfile.ZipFile(sanitised_data, "a", zipfile.ZIP_DEFLATED) as zf:
             zf.writestr("meta.xml", metadata)
 
+        sanitised_data.seek(0)
         return sanitised_data
 
 
@@ -141,6 +147,8 @@ class MicrosoftDocExtractor(BaseExtractMetaData):
                         output_file.writestr(
                             sub_file.filename, sanitised_core_properties
                         )
+
+        sanitised_data.seek(0)
         return sanitised_data
 
 

--- a/v2_api_client/shared/upload_handler/tests.py
+++ b/v2_api_client/shared/upload_handler/tests.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import zipfile
 
@@ -171,6 +172,19 @@ class TestDocumentMetadata:
         self.xlsx.save(self.xlsx_file)
 
         self.xlsx_document = Extractor()
+
+    def create_zip_file(self):
+        self.create_pdf_document()
+        self.create_xlsx_document()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            shutil.copy(self.pdf_file, os.path.join(tmpdirname, "fixture.pdf"))
+            shutil.copy(self.xlsx_file, os.path.join(tmpdirname, "fixture.xlsx"))
+            self.zip_file = shutil.make_archive(
+                os.path.join(os.path.dirname(__file__), "fixture"),
+                "zip",
+                tmpdirname
+            )
+
 
     def create_odf_document(self, file_type):
         odf_filepath = os.path.join(


### PR DESCRIPTION
Changing ODFExtractor to a better name.

sanitised data returned by the extractors is now definitely seeked to 0 so it can be read later on.

ZIpfile extractor improved to just copy files which are not extracted