### PR TITLE
Feature - TRSV2-597 - Caseworker ROI approval merge process

### DIFF
--- a/v2_api_client/library/submissions.py
+++ b/v2_api_client/library/submissions.py
@@ -5,8 +5,8 @@ from v2_api_client.library import BaseAPIClient, TRSObject
 
 class SubmissionObject(TRSObject):
     def add_organisation_to_registration_of_interest(
-        self,
-        organisation_id,
+            self,
+            organisation_id,
     ):
         return self.custom_action(
             "put",
@@ -26,6 +26,17 @@ class SubmissionObject(TRSObject):
         )
 
 
+class SubmissionOrganisationMergeRecordObject(TRSObject):
+    def update(self, data: dict, fields: list = None) -> TRSObject:
+        """The SubmissionOrganisationMergeRecordViewSet requires an organisation_id query parameter to
+        be passed in the URL, so we need to override the update method to use the self.retrieval_url
+        which contains the query parameter (by definition), otherwise we get a 404 error."""
+        data = self.api_client.patch(
+            self.retrieval_url, data=data
+        )
+        return self.__class__(data=data, api_client=self.api_client, object_id=data["id"])
+
+
 class SubmissionsAPIClient(BaseAPIClient):
     base_endpoint = "submissions"
     trs_object_class = SubmissionObject
@@ -33,3 +44,4 @@ class SubmissionsAPIClient(BaseAPIClient):
 
 class SubmissionOrganisationMergeRecordAPIClient(BaseAPIClient):
     base_endpoint = "submission_organisation_merge_records"
+    trs_object_class = SubmissionOrganisationMergeRecordObject


### PR DESCRIPTION
Changed SubmissionOrganisationMergeREcord update function to use the retrieval_url as it requires an organisation_id to be passed as a query parameter